### PR TITLE
Update .cookiecutter.json

### DIFF
--- a/.cookiecutter.json
+++ b/.cookiecutter.json
@@ -14,7 +14,7 @@
         "max_nautobot_version": "2.9999",
         "camel_name": "NautobotDataValidationEngine",
         "project_short_description": "Provides UI to build custom data validation rules for data in Nautobot",
-        "model_class_name": "None",
+        "model_class_name": "ValidationRule",
         "open_source_license": "Apache-2.0",
         "docs_base_url": "https://docs.nautobot.com",
         "docs_app_url": "https://docs.nautobot.com/projects/data-validation/en/latest",

--- a/changes/185.housekeeping
+++ b/changes/185.housekeeping
@@ -1,0 +1,1 @@
+Changed model_class_name in .cookiecutter.json to a valid model to help with drift management.


### PR DESCRIPTION
Due to the way that Drift Manager uses the .cookiecutter.json file, we need to change the model_class_name to a valid model in BGP models to help us track drift in files that would be removed if the model_class_name=None.