### PR TITLE
201 decimalfield cannot be validated with minmax validator

### DIFF
--- a/changes/201.changed
+++ b/changes/201.changed
@@ -1,0 +1,1 @@
+Disallow validating DecimalField types with MinMaxValidationRule

--- a/nautobot_data_validation_engine/custom_validators.py
+++ b/nautobot_data_validation_engine/custom_validators.py
@@ -14,6 +14,7 @@ import logging
 import pkgutil
 import re
 import sys
+from decimal import Decimal
 from typing import Optional
 
 from django.contrib.contenttypes.models import ContentType
@@ -95,7 +96,7 @@ class BaseValidator(PluginCustomValidator):
                     }
                 )
 
-            elif not isinstance(field_value, (int, float)):
+            elif not isinstance(field_value, (int, float, Decimal)):
                 self.validation_error(
                     {
                         rule.field: f"Unable to validate against min/max rule {rule} because the field value is not numeric."

--- a/nautobot_data_validation_engine/models.py
+++ b/nautobot_data_validation_engine/models.py
@@ -178,7 +178,6 @@ class MinMaxValidationRule(ValidationRule):
             )
 
         whitelisted_field_types = (
-            models.DecimalField,
             models.FloatField,
             models.IntegerField,
         )
@@ -186,6 +185,7 @@ class MinMaxValidationRule(ValidationRule):
         blacklisted_field_types = (
             models.AutoField,
             models.BigAutoField,
+            models.DecimalField,
         )
 
         model_field = self.content_type.model_class()._meta.get_field(self.field)

--- a/nautobot_data_validation_engine/models.py
+++ b/nautobot_data_validation_engine/models.py
@@ -178,6 +178,7 @@ class MinMaxValidationRule(ValidationRule):
             )
 
         whitelisted_field_types = (
+            models.DecimalField,
             models.FloatField,
             models.IntegerField,
         )
@@ -185,7 +186,6 @@ class MinMaxValidationRule(ValidationRule):
         blacklisted_field_types = (
             models.AutoField,
             models.BigAutoField,
-            models.DecimalField,
         )
 
         model_field = self.content_type.model_class()._meta.get_field(self.field)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Data Validation Engine! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #201 

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

Blacklisted DecimalField type from MinMaxRule as it's not a number

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [X] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
