### PR TITLE
Add support for custom fields in data compliance rules

### DIFF
--- a/changes/205.fixed
+++ b/changes/205.fixed
@@ -1,0 +1,1 @@
+Added support for validating custom fields by referencing them as cf_<custom_field_name> in ComplianceError exceptions

--- a/docs/user/app_data_compliance.md
+++ b/docs/user/app_data_compliance.md
@@ -18,6 +18,9 @@ Any `DataComplianceRule` class can have a `name` defined to provide a friendly n
 > 
 > For example, if a user fixes an object attribute that was incompliant with a built-in rule and then navigates to its `Data Compliance` tab, the object will still show as invalid for that built-in rule. This will remain the case until the job is ran again with the `Run built-in validation rules?` option checked.
 
+!!! note
+    When raising a ComplianceError, the attribute must exist on the object. To raise errors for custom fields, use cf_custom_field_name as the attribute name.
+
 ## How to Use
 
 ### Step 1. Create Data Compliance Rules

--- a/nautobot_data_validation_engine/custom_validators.py
+++ b/nautobot_data_validation_engine/custom_validators.py
@@ -283,7 +283,10 @@ class DataComplianceRule(CustomValidator):
         """Generate a DataCompliance object based on the given parameters."""
         instance = self.context["object"]
         attribute_value = None
-        if attribute:
+        if attribute and attribute.startswith("cf_"):
+            # Custom field attributes are prefixed with 'cf_'
+            attribute_value = instance.cf.get(attribute[3:], None)
+        elif attribute:
             attribute_value = getattr(instance, attribute)
         else:
             attribute = "__all__"

--- a/nautobot_data_validation_engine/custom_validators.py
+++ b/nautobot_data_validation_engine/custom_validators.py
@@ -295,7 +295,7 @@ class DataComplianceRule(CustomValidator):
             defaults={
                 "last_validation_date": self.result_date,
                 "validated_object_str": str(instance),
-                "validated_attribute_value": str(attribute_value) if attribute_value else "",
+                "validated_attribute_value": str(attribute_value)[:254] if attribute_value else "",
                 "message": message,
                 "valid": valid,
             },

--- a/nautobot_data_validation_engine/tests/test_data_compliance_rules.py
+++ b/nautobot_data_validation_engine/tests/test_data_compliance_rules.py
@@ -78,3 +78,34 @@ class TestCompliance(TestCase):
             len(DataCompliance.objects.filter(compliance_class_name=TestFailedDataComplianceRule.__name__)),
             5,
         )
+
+    def test_custom_field_attribute_value(self):
+        # Simulate a Location with a custom field value
+        self.s.cf = {"foo": "bar"}
+        # Patch DataComplianceRule.context to include our instance
+        rule = TestPassedDataComplianceRule(self.s)
+        rule.context = {"object": self.s}
+
+        # Call _create_data_compliance_object with a custom field attribute
+        obj = rule._create_data_compliance_object(attribute="cf_foo", valid=True, message="msg")
+        self.assertEqual(obj.validated_attribute, "cf_foo")
+        self.assertEqual(obj.validated_attribute_value, "bar")
+
+    def test_custom_field_attribute_value_missing(self):
+        # Simulate a Location with no custom field value
+        self.s.cf = {}
+        rule = TestPassedDataComplianceRule(self.s)
+        rule.context = {"object": self.s}
+
+        obj = rule._create_data_compliance_object(attribute="cf_missing", valid=True, message="msg")
+        self.assertEqual(obj.validated_attribute, "cf_missing")
+        self.assertIsNone(obj.validated_attribute_value)
+
+    def test_regular_attribute_value(self):
+        # Test with a regular attribute
+        rule = TestPassedDataComplianceRule(self.s)
+        rule.context = {"object": self.s}
+
+        obj = rule._create_data_compliance_object(attribute="name", valid=True, message="msg")
+        self.assertEqual(obj.validated_attribute, "name")
+        self.assertEqual(obj.validated_attribute_value, self.s.name)


### PR DESCRIPTION

# Closes: #205


## What's Changed

This proposed change allows you to validate custom fields by referencing them as `cf_<custom_field_name` in `ComplianceError` exceptions.

This PR is more of a proposal than a final solution — I’m not sure if this is the approach you’d prefer for solving the issue, but I wanted to share some working code and get your feedback.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
