### PR TITLE
Closes #218: Updated rendering of boolean fields in rule tables to match the rule detail view and Nautobot core

### DIFF
--- a/changes/218.fixed
+++ b/changes/218.fixed
@@ -1,0 +1,1 @@
+Updated rendering of boolean fields in rule tables to match the rule detail view and Nautobot core.

--- a/nautobot_data_validation_engine/tables.py
+++ b/nautobot_data_validation_engine/tables.py
@@ -2,7 +2,7 @@
 
 import django_tables2 as tables
 from django.utils.html import format_html
-from nautobot.core.tables import BaseTable, TagColumn, ToggleColumn
+from nautobot.core.tables import BaseTable, BooleanColumn, TagColumn, ToggleColumn
 
 from nautobot_data_validation_engine.models import (
     DataCompliance,
@@ -22,6 +22,8 @@ class RegularExpressionValidationRuleTable(BaseTable):
 
     pk = ToggleColumn()
     name = tables.LinkColumn(order_by=("name",))
+    enabled = BooleanColumn()
+    context_processing = BooleanColumn()
     tags = TagColumn()
 
     class Meta(BaseTable.Meta):
@@ -61,6 +63,7 @@ class MinMaxValidationRuleTable(BaseTable):
 
     pk = ToggleColumn()
     name = tables.LinkColumn(order_by=("name",))
+    enabled = BooleanColumn()
     tags = TagColumn()
 
     class Meta(BaseTable.Meta):
@@ -100,6 +103,7 @@ class RequiredValidationRuleTable(BaseTable):
 
     pk = ToggleColumn()
     name = tables.LinkColumn(order_by=("name",))
+    enabled = BooleanColumn()
     tags = TagColumn()
 
     class Meta(BaseTable.Meta):
@@ -135,6 +139,7 @@ class UniqueValidationRuleTable(BaseTable):
 
     pk = ToggleColumn()
     name = tables.LinkColumn(order_by=("name",))
+    enabled = BooleanColumn()
     tags = TagColumn()
 
     class Meta(BaseTable.Meta):
@@ -186,6 +191,7 @@ class DataComplianceTable(BaseTable):
     id = tables.Column(linkify=True, verbose_name="ID")
     validated_object = tables.RelatedLinkColumn()
     validated_attribute = ValidatedAttributeColumn()
+    valid = BooleanColumn()
 
     def order_validated_object(self, queryset, is_descending):
         """Reorder table by string representation of validated_object."""
@@ -226,6 +232,7 @@ class DataComplianceTableTab(BaseTable):  # pylint: disable=nb-sub-class-name
     """Base table for viewing the DataCompliance related to a single object."""
 
     validated_attribute = ValidatedAttributeColumn()
+    valid = BooleanColumn()
 
     class Meta(BaseTable.Meta):
         """Meta class for DataComplianceTableTab."""


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Data Validation Engine! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #218 

# IMPORTANT: This app will be integrated into Nautobot v3.0. All pull requests into this repository should be ported to the [nautobot](https://github.com/nautobot/nautobot) repo.

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

Updated the table view to render the correctly formatted check/x boxes. 'Before' samples are taken from demo.nautobot.com while 'after' samples are taken from my local dev environment.

### MinMax Rule Table

#### Before
<img width="1380" height="112" alt="Screenshot 2025-10-15 at 2 22 51 AM" src="https://github.com/user-attachments/assets/70c5b268-25b6-401d-929e-d532475b4fb8" />

#### After
<img width="1384" height="111" alt="Screenshot 2025-10-15 at 2 31 49 AM" src="https://github.com/user-attachments/assets/659022d6-32ee-4144-9939-4d23e8da4f4d" />

### Regex Rule Table

#### Before
<img width="1383" height="151" alt="Screenshot 2025-10-15 at 2 20 57 AM" src="https://github.com/user-attachments/assets/19b22de4-3920-495a-9310-39ef019e909e" />

#### After
<img width="1381" height="108" alt="Screenshot 2025-10-15 at 2 21 35 AM" src="https://github.com/user-attachments/assets/f94c03ee-affd-4ccb-8026-a022344d1f01" />

### Required Rule Table

#### Before
<img width="1386" height="113" alt="Screenshot 2025-10-15 at 2 23 40 AM" src="https://github.com/user-attachments/assets/9c52f750-8be1-44e9-8384-194c9ca3288e" />

#### After
<img width="1384" height="106" alt="Screenshot 2025-10-15 at 2 32 33 AM" src="https://github.com/user-attachments/assets/835a5d9f-9c1d-41a8-9f96-02b20914677f" />

### Unique Rule Table

#### Before
<img width="1380" height="111" alt="Screenshot 2025-10-15 at 2 27 54 AM" src="https://github.com/user-attachments/assets/2b3e0401-e520-4dce-a592-9fcd5c1742c0" />

#### After
<img width="1381" height="108" alt="Screenshot 2025-10-15 at 2 32 57 AM" src="https://github.com/user-attachments/assets/cb3ce209-7d98-4c5d-a876-a9f0848a0fa6" />


## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
