### PR TITLE
Release v3.4.0

### DIFF
--- a/changes/+nautobot-app-v2.7.0.housekeeping
+++ b/changes/+nautobot-app-v2.7.0.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.7.0`.

--- a/changes/+nautobot-app-v2.7.1.housekeeping
+++ b/changes/+nautobot-app-v2.7.1.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.7.1`.

--- a/changes/204.fixed
+++ b/changes/204.fixed
@@ -1,1 +1,0 @@
-replaced deprecated find_module

--- a/changes/207.documentation
+++ b/changes/207.documentation
@@ -1,1 +1,0 @@
-Added Analytics GTM template override only to the public ReadTheDocs build.

--- a/changes/218.fixed
+++ b/changes/218.fixed
@@ -1,1 +1,0 @@
-Updated rendering of boolean fields in rule tables to match the rule detail view and Nautobot core.

--- a/docs/admin/release_notes/version_3.4.md
+++ b/docs/admin/release_notes/version_3.4.md
@@ -1,0 +1,26 @@
+# v3.4 Release Notes
+
+This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Release Overview
+
+- Fixed Python 3.12 compatibility issues.
+- Changed minimum Nautobot version to 2.4.20.
+- Dropped support for Python 3.9.
+
+<!-- towncrier release notes start -->
+## [v3.4.0 (2025-12-05)](https://github.com/nautobot/nautobot-app-data-validation-engine/releases/tag/v3.4.0)
+
+### Fixed
+
+- [#204](https://github.com/nautobot/nautobot-app-data-validation-engine/issues/204) - Fixed Python 3.12 compatibility issues.
+- [#218](https://github.com/nautobot/nautobot-app-data-validation-engine/issues/218) - Updated rendering of boolean fields in rule tables to match the Nautobot standard.
+
+### Documentation
+
+- [#207](https://github.com/nautobot/nautobot-app-data-validation-engine/issues/207) - Added Analytics GTM template override only to the public ReadTheDocs build.
+
+### Housekeeping
+
+- Rebaked from the cookie `nautobot-app-v2.7.0`.
+- Rebaked from the cookie `nautobot-app-v2.7.1`.

--- a/docs/admin/release_notes/version_3.4.md
+++ b/docs/admin/release_notes/version_3.4.md
@@ -4,6 +4,8 @@ This document describes all new features and changes in the release. The format 
 
 ## Release Overview
 
+The functionality of this app has been moved to Nautobot as of version 3.0.0. The 3.4.x release of this app will continue to support Nautobot v2.4.x and will be maintained for security and critical bug fixes only. All new feature requests for data validation should go directly to [Nautobot](https://github.com/nautobot/nautobot).
+
 - Fixed Python 3.12 compatibility issues.
 - Changed minimum Nautobot version to 2.4.20.
 - Dropped support for Python 3.9.

--- a/docs/admin/release_notes/version_3.4.md
+++ b/docs/admin/release_notes/version_3.4.md
@@ -4,7 +4,7 @@ This document describes all new features and changes in the release. The format 
 
 ## Release Overview
 
-The functionality of this app has been moved to Nautobot as of version 3.0.0. The 3.4.x release of this app will continue to support Nautobot v2.4.x and will be maintained for security and critical bug fixes only. All new feature requests for data validation should go directly to [Nautobot](https://github.com/nautobot/nautobot).
+The functionality of this app has been moved to Nautobot as of [version 3.0.0](https://docs.nautobot.com/projects/core/en/stable/release-notes/version-3.0/). The 3.4.x release of this app will continue to support Nautobot v2.4.x and will be maintained for security and critical bug fixes only. All new feature requests for data validation should go directly to [Nautobot](https://github.com/nautobot/nautobot).
 
 - Fixed Python 3.12 compatibility issues.
 - Changed minimum Nautobot version to 2.4.20.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,6 +117,7 @@ nav:
       - Compatibility Matrix: "admin/compatibility_matrix.md"
       - Release Notes:
           - "admin/release_notes/index.md"
+          - v3.4: "admin/release_notes/version_3.4.md"
           - v3.3: "admin/release_notes/version_3.3.md"
           - v3.2: "admin/release_notes/version_3.2.md"
           - v3.1: "admin/release_notes/version_3.1.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-data-validation-engine"
-version = "3.4.0a0"
+version = "3.4.0"
 description = "Provides UI to build custom data validation rules for data in Nautobot"
 authors = ["Network to Code, LLC <info@networktocode.com>"]
 license = "Apache-2.0"
@@ -164,7 +164,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.towncrier]
 package = "nautobot_data_validation_engine"
 directory = "changes"
-filename = "docs/admin/release_notes/version_3.3.md"
+filename = "docs/admin/release_notes/version_3.4.md"
 template = "development/towncrier_template.j2"
 start_string = "<!-- towncrier release notes start -->"
 issue_format = "[#{issue}](https://github.com/nautobot/nautobot-app-data-validation-engine/issues/{issue})"


### PR DESCRIPTION
# v3.4 Release Notes

This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

## Release Overview

The functionality of this app has been moved to Nautobot as of [version 3.0.0](https://docs.nautobot.com/projects/core/en/stable/release-notes/version-3.0/). The 3.4.x release of this app will continue to support Nautobot v2.4.x and will be maintained for security and critical bug fixes only. All new feature requests for data validation should go directly to [Nautobot](https://github.com/nautobot/nautobot).

- Fixed Python 3.12 compatibility issues.
- Changed minimum Nautobot version to 2.4.20.
- Dropped support for Python 3.9.

<!-- towncrier release notes start -->
## [v3.4.0 (2025-12-05)](https://github.com/nautobot/nautobot-app-data-validation-engine/releases/tag/v3.4.0)

### Fixed

- [#204](https://github.com/nautobot/nautobot-app-data-validation-engine/issues/204) - Fixed Python 3.12 compatibility issues.
- [#218](https://github.com/nautobot/nautobot-app-data-validation-engine/issues/218) - Updated rendering of boolean fields in rule tables to match the Nautobot standard.

### Documentation

- [#207](https://github.com/nautobot/nautobot-app-data-validation-engine/issues/207) - Added Analytics GTM template override only to the public ReadTheDocs build.

### Housekeeping

- Rebaked from the cookie `nautobot-app-v2.7.0`.
- Rebaked from the cookie `nautobot-app-v2.7.1`.
