### PR TITLE
update upstream testing workflow

### DIFF
--- a/.github/workflows/upstream_testing.yml
+++ b/.github/workflows/upstream_testing.yml
@@ -3,12 +3,26 @@ name: "Nautobot Upstream Monitor"
 
 on:  # yamllint disable-line rule:truthy rule:comments
   schedule:
-    - cron: "0 4 */2 * *"  # every other day at midnight
+    - cron: "0 4 */2 * *"  # every other day at 4 AM
   workflow_dispatch:
 
 jobs:
   upstream-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # - nautobot_branch: "develop"
+          #   app_branch: "main"
+          # - nautobot_branch: "next"
+          #   app_branch: "main"
+          - nautobot_branch: "ltm-2.4"
+            app_branch: "ltm-2.4"
+          # - nautobot_branch: "next-4.0"
+          #   app_branch: "next-4.0"
     uses: "nautobot/nautobot/.github/workflows/plugin_upstream_testing_base.yml@develop"
     with:  # Below could potentially be collapsed into a single argument if a concrete relationship between both is enforced
       invoke_context_name: "NAUTOBOT_DATA_VALIDATION_ENGINE"
-      plugin_name: "nautobot-data-validation-engine"
+      app_name: "nautobot-data-validation-engine"
+      nautobot_branch: "${{ matrix.nautobot_branch }}"
+      app_branch: "${{ matrix.app_branch }}"

--- a/.github/workflows/upstream_testing.yml
+++ b/.github/workflows/upstream_testing.yml
@@ -12,14 +12,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - nautobot_branch: "develop"
-          #   app_branch: "main"
-          # - nautobot_branch: "next"
-          #   app_branch: "main"
+        # - nautobot_branch: "develop"
+        #   app_branch: "main"
+        # - nautobot_branch: "next"
+        #   app_branch: "main"
           - nautobot_branch: "ltm-2.4"
             app_branch: "ltm-2.4"
-          # - nautobot_branch: "next-4.0"
-          #   app_branch: "next-4.0"
+        # - nautobot_branch: "next-4.0"
+        #   app_branch: "next-4.0"
     uses: "nautobot/nautobot/.github/workflows/plugin_upstream_testing_base.yml@develop"
     with:  # Below could potentially be collapsed into a single argument if a concrete relationship between both is enforced
       invoke_context_name: "NAUTOBOT_DATA_VALIDATION_ENGINE"


### PR DESCRIPTION
Since this app uses ltm-2.4 as the default branch we needed the updates from the most recent develop cookie ported manually.